### PR TITLE
add github action to publish to npm when the package.json version changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish on version change
+
+on:
+  push:
+    branches: main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛒
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18 🛒
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Node Packages 🛒
+        run: npm ci
+
+      - name: Lint 🧽
+        run: npm run lint
+
+      - name: Run Vi tests 🏃
+        run: npm run test:unit
+
+      - name: Install playwright browsers 🛒
+        run: npx playwright install --with-deps
+
+      - name: Run Playwrite tests 🏃
+        run: npm run test
+
+      - name: Publish to npm if needed 🚀
+        id: publish
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          strategy: upgrade
+
+      - name: Comment version on commit 💬
+        if: ${{ steps.publish.outputs.type }}
+        uses: peter-evans/commit-comment@v2
+        with:
+          body: |
+            This has been published to NPM as [${{steps.publish.outputs.id}}][1] 🚀
+
+            [1]: https://www.npmjs.com/package/${{steps.publish.outputs.name}}/v/${{steps.publish.outputs.version}}


### PR DESCRIPTION
Adds a github action set to run on pushes to main that will:
- Run Tests to ensure we don't publish something with failing tests
- Runs the [npm-publish](https://github.com/marketplace/actions/npm-publish) to publish to npm if the version in the `package.json` is not already published
- Runs the [commit-comment](https://github.com/marketplace/actions/commit-comment) to add a comment about the version being published to the commit that caused it to happen

PR to main as the action only happens on main, but I can change it to uat as usual if you'd prefer

The action is untested as I'm not sure of a great way to test without just trying it on main

We will need a secret added as `NPM_TOKEN`