### PR TITLE
Add carousel component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
 			"version": "0.0.7",
 			"license": "MIT",
 			"dependencies": {
-				"svelte-headlessui": "^0.0.15"
+				"esm-env": "^1.0.0",
+				"svelte-headlessui": "^0.0.15",
+				"swiper": "^9.3.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.33.0",
@@ -2563,8 +2565,7 @@
 		"node_modules/esm-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
-			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
-			"dev": true
+			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA=="
 		},
 		"node_modules/espree": {
 			"version": "9.5.1",
@@ -5067,6 +5068,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ssr-window": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+			"integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5356,6 +5362,27 @@
 			"peerDependencies": {
 				"svelte": "^3.55",
 				"typescript": "^4.9.4 || ^5.0.0"
+			}
+		},
+		"node_modules/swiper": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-9.3.0.tgz",
+			"integrity": "sha512-iELlQVvWLdyfUjQSfhg8UTKBvgfm3uCfv3wJ3f9wbSWP6spzoOTLcob87A8ywPS2FRc552JmrnyL5+LYfN8j9Q==",
+			"funding": [
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/swiperjs"
+				},
+				{
+					"type": "open_collective",
+					"url": "http://opencollective.com/swiper"
+				}
+			],
+			"dependencies": {
+				"ssr-window": "^4.0.2"
+			},
+			"engines": {
+				"node": ">= 4.7.0"
 			}
 		},
 		"node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
 		"!dist/**/*.spec.*"
 	],
 	"dependencies": {
-		"svelte-headlessui": "^0.0.15"
+		"esm-env": "^1.0.0",
+		"svelte-headlessui": "^0.0.15",
+		"swiper": "^9.3.0"
 	},
 	"peerDependencies": {
 		"svelte": "^3.54.0"

--- a/src/lib/Carousel.svelte
+++ b/src/lib/Carousel.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import Swiper, { Navigation } from 'swiper';
+	import 'swiper/css';
+	import 'swiper/css/navigation';
+	import { onMount } from 'svelte';
+	import { BROWSER } from 'esm-env';
+
+	let className = '';
+	export { className as class };
+	/**
+	 * Page to link out to when JavaScript is disabled and the user clicks the next button
+	 */
+	export let viewMoreHref: string | undefined = undefined;
+	type Item = $$Generic;
+	export let items: Item[];
+	export let itemClass = '';
+
+	let carouselEl: HTMLElement | undefined = undefined;
+	let navButtonNext: HTMLElement | undefined = undefined;
+	let navButtonPrev: HTMLElement | undefined = undefined;
+
+	onMount(() => {
+		if (!carouselEl) {
+			return;
+		}
+
+		const instance = new Swiper(carouselEl, {
+			modules: [Navigation],
+			slidesPerView: 'auto',
+
+			navigation: {
+				nextEl: navButtonNext,
+				prevEl: navButtonPrev
+			}
+		});
+		return () => {
+			instance.destroy();
+		};
+	});
+</script>
+
+<div bind:this={carouselEl} class="relative swiper select-none {className}">
+	<ul class="swiper-wrapper">
+		{#each items as item}
+			<li class="swiper-slide {itemClass}">
+				<slot {item} />
+			</li>
+		{/each}
+	</ul>
+
+	{#if BROWSER}
+		<button bind:this={navButtonPrev} class="swiper-button-prev !text-gray-300 drop-shadow">
+			<span class="sr-only">Previous</span>
+		</button>
+		<button bind:this={navButtonNext} class="swiper-button-next !text-gray-300 drop-shadow">
+			<span class="sr-only">Next</span>
+		</button>
+	{:else if viewMoreHref != null}
+		<a href={viewMoreHref} class="view-more swiper-button-next !text-gray-300 drop-shadow">
+			<span class="sr-only">View More</span>
+		</a>
+	{/if}
+</div>
+
+<style>
+	.view-more {
+		/* When the user has javascript disabled (or it has yet to load), the view more button will
+		be shown to allow the user to still see all items in the carousel, albeit in a different
+		view. We delay the visibility of this for a second so that javascript users don't see an
+		arrow appear briefly then dissapear if there are not enough carousel items to require an
+		arrow  */
+		opacity: 0;
+		animation: fadeIn 150ms 1000ms forwards;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export { default as BottomNav } from './BottomNav.svelte';
 export { default as Breadcrumbs } from './Breadcrumbs.svelte';
 export { default as CancelButton } from './CancelButton.svelte';
 export { default as Card } from './Card.svelte';
+export { default as Carousel } from './Carousel.svelte';
 export { default as Chip } from './Chip.svelte';
 export { default as CodeSnippet } from './CodeSnippet.svelte';
 export { default as CookieBanner } from './CookieBanner.svelte';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 		{ href: '/Breadcrumbs', label: 'Breadcrumbs' },
 		{ href: '/CancelButton', label: 'CancelButton' },
 		{ href: '/Card', label: 'Card' },
+		{ href: '/Carousel', label: 'Carousel' },
 		{ href: '/Chip', label: 'Chip' },
 		{ href: '/CodeSnippet', label: 'CodeSnippet' },
 		{ href: '/CookieBanner', label: 'CookieBanner' },
@@ -43,7 +44,7 @@
 			</ul>
 		</nav>
 
-		<div class="grow">
+		<div class="grow overflow-x-hidden">
 			<div class="h-full p-6 bg-white border border-gray-200 rounded-md overflow-y-auto">
 				<slot />
 			</div>

--- a/src/routes/Carousel/+page.svelte
+++ b/src/routes/Carousel/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import ExamplePage from '../ExamplePage.svelte';
+	import ExampleCarousel from './ExampleCarousel.svelte';
+	import usage from './ExampleCarousel.svelte?raw';
+</script>
+
+<ExamplePage title="Carousel" {usage}>
+	<ExampleCarousel />
+</ExamplePage>

--- a/src/routes/Carousel/ExampleCarousel.svelte
+++ b/src/routes/Carousel/ExampleCarousel.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { Carousel } from '$lib';
+
+	const items = Array.from({ length: 20 }).map(
+		(_, i) => `https://picsum.photos/200/200?random=${i}`
+	);
+</script>
+
+<Carousel {items} let:item class="!-mx-6 !px-6" itemClass="!w-[200px] mr-2">
+	<img src={item} width="200" height="200" alt="" class="rounded" />
+</Carousel>


### PR DESCRIPTION
Adds a horizontal carousel component using `swiper` under the hood. Currently this focuses on catering for the one variant that we are using, but swiper has a lot of options and there is room for supporting those different variants as and when we need them.

Not too sure on a great way of testing this so I've left it for now