### PR TITLE
add implementation guidelines page

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-gray-100 dark:bg-gray-900">
+<html lang="en" class="h-full">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
-	<body class="h-full">
+	<body class="h-full bg-gray-100 dark:bg-gray-900 dark:text-white">
 		<div class="contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,30 +4,33 @@
 
 	const routes = [
 		{ href: '/', label: 'Home' },
-		{ href: '/Accordion', label: 'Accordion' },
-		{ href: '/Alert', label: 'Alert' },
-		{ href: '/BackButton', label: 'BackButton' },
-		{ href: '/Banner', label: 'Banner' },
-		{ href: '/BottomNav', label: 'BottomNav' },
-		{ href: '/Breadcrumbs', label: 'Breadcrumbs' },
-		{ href: '/CancelButton', label: 'CancelButton' },
-		{ href: '/Card', label: 'Card' },
-		{ href: '/Carousel', label: 'Carousel' },
-		{ href: '/Chip', label: 'Chip' },
-		{ href: '/CodeSnippet', label: 'CodeSnippet' },
-		{ href: '/CookieBanner', label: 'CookieBanner' },
-		{ href: '/DarkMode', label: 'DarkMode' },
-		{ href: '/Drawer', label: 'Drawer' },
-		{ href: '/Dropdown', label: 'Dropdown' },
-		{ href: '/Footer', label: 'Footer' },
-		{ href: '/Jumbotron', label: 'Jumbotron' },
-		{ href: '/Loader', label: 'Loader' },
-		{ href: '/Modal', label: 'Modal' },
-		{ href: '/NavBar', label: 'NavBar' },
-		{ href: '/PrimaryButton', label: 'PrimaryButton' },
-		{ href: '/Stepper', label: 'Stepper' },
-		{ href: '/TitleDescription', label: 'TitleDescription' },
-		{ href: '/Tooltip', label: 'Tooltip' }
+		{ href: '/guidelines', label: 'Implementation Guidelines' }
+	];
+	const components = [
+		{ name: 'Accordion' },
+		{ name: 'Alert' },
+		{ name: 'BackButton' },
+		{ name: 'Banner' },
+		{ name: 'BottomNav' },
+		{ name: 'Breadcrumbs' },
+		{ name: 'CancelButton' },
+		{ name: 'Card' },
+		{ name: 'Carousel' },
+		{ name: 'Chip' },
+		{ name: 'CodeSnippet' },
+		{ name: 'CookieBanner' },
+		{ name: 'DarkMode' },
+		{ name: 'Drawer' },
+		{ name: 'Dropdown' },
+		{ name: 'Footer' },
+		{ name: 'Jumbotron' },
+		{ name: 'Loader' },
+		{ name: 'Modal' },
+		{ name: 'NavBar' },
+		{ name: 'PrimaryButton' },
+		{ name: 'Stepper' },
+		{ name: 'TitleDescription' },
+		{ name: 'Tooltip' }
 	];
 </script>
 
@@ -46,10 +49,28 @@
 					</li>
 				{/each}
 			</ul>
+			<hr class="border-gray-300 dark:border-gray-700 mx-2 my-4" />
+			<h3 class="text-sm font-semibold tracking-tight ml-2.5 mb-2 text-gray-600 dark:text-gray-400">
+				Components
+			</h3>
+			<ul class="space-y-0.5">
+				{#each components as component}
+					<li>
+						<a
+							href="/{component.name}"
+							class="block px-2.5 py-1.5 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"
+						>
+							{component.name}
+						</a>
+					</li>
+				{/each}
+			</ul>
 		</nav>
 
 		<div class="grow overflow-x-hidden">
-			<div class="h-full p-6 border border-gray-200 rounded-md overflow-y-auto">
+			<div
+				class="bg-white dark:bg-gray-800 h-full p-6 border border-gray-200 dark:border-gray-700 rounded-md overflow-y-auto"
+			>
 				<slot />
 			</div>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 <div class="prose prose-red prose-sm dark:prose-invert">
 	<h1>PeoplePlus Svelte Components</h1>
 	<p>A collection of high quality, accessible components for Svelte and SvelteKit.</p>
-	<h2>Goals</h2>
+	<h2 id="goals">Goals</h2>
 	<ul>
 		<li>
 			<strong>Accessible by Default</strong>

--- a/src/routes/guidelines/+page.svelte
+++ b/src/routes/guidelines/+page.svelte
@@ -1,0 +1,57 @@
+<svelte:head>
+	<title>Implementation Guidelines &middot; PeoplePlus Svelte Components</title>
+</svelte:head>
+
+<div class="prose prose-sm prose-red dark:prose-invert">
+	<h1>Implementation Guidelines</h1>
+	<p class="lead">
+		Below are some guidelines that components in this library should follow. Use this document to
+		help guide the design of the component APIs and their behaviour.
+	</p>
+	<p>
+		The following principles apply to writing components for this component library. Some of the
+		guidelines here may not apply or make sense in an application context.
+	</p>
+	<div>
+		<h3>Keep project goals in mind</h3>
+		<p>
+			Ensure all contributions consider the goals of the project layed out on the <a href="/#goals"
+				>homepage</a
+			>
+			including following
+			<a href="https://www.w3.org/WAI/standards-guidelines/">accesibility guidelines</a>.
+		</p>
+	</div>
+	<div>
+		<h3>Prefer slots over properties</h3>
+		<p>
+			Where a property will just be rendered into the DOM, prefer to provide it via slots instead of
+			props.
+		</p>
+		<h4>Example</h4>
+		<p>Prefer this:</p>
+		<pre>{'<InputLabel>My input label</InputLabel>'}</pre>
+		<p>Over this:</p>
+		<pre>{'<InputLabel text="My input label" />'}</pre>
+		<h4>Rationale</h4>
+		<p>Slots allow for more than just text, for example icons, bold & italics, links.</p>
+	</div>
+	<div>
+		<h3>Prefer components over multiple properties</h3>
+		<p>
+			Where there are multiple properties referring to one aspect of the component, prefer to
+			separate that section out into a component that can then be provided by a slot.
+		</p>
+		<h4>Example</h4>
+		<p>Prefer this:</p>
+		<pre>{'<Navbar><NavBarTitle href="/">PeoplePlus</NavBarTitle></Navbar>'}</pre>
+		<p>Over this:</p>
+		<pre>{'<Navbar title="PeoplePlus" titleHref="/" />'}</pre>
+		<h4>Rationale</h4>
+		<p>
+			Along with the benefits provided by using a slot over a property for the text content, this
+			also groups related properties, and makes it easier to expose many properties and events
+			without needing to prefix them all, or even using `$$restProps`.
+		</p>
+	</div>
+</div>


### PR DESCRIPTION
Adds an implementation guidelines page. Currently just has two guidelines on top of the goals set out on the homepage.
We can add more as we discover/think of them.