### PR TITLE
add video player component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"esm-env": "^1.0.0",
+				"just-debounce-it": "^3.2.0",
 				"just-throttle": "^4.2.0",
 				"svelte-headlessui": "^0.0.15",
 				"tailwind-merge": "^1.12.0"
@@ -4369,6 +4370,11 @@
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
 			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
+		},
+		"node_modules/just-debounce-it": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+			"integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
 		},
 		"node_modules/just-throttle": {
 			"version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	],
 	"dependencies": {
 		"esm-env": "^1.0.0",
+		"just-debounce-it": "^3.2.0",
 		"just-throttle": "^4.2.0",
 		"svelte-headlessui": "^0.0.15",
 		"tailwind-merge": "^1.12.0"

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,7 @@ const headers: Handle = async function handle({ event, resolve }) {
 	response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');
 	response.headers.set(
 		'Permissions-Policy',
-		'camera=(), display-capture=(), fullscreen=(), geolocation=(), microphone=()'
+		'camera=(), display-capture=(), fullscreen=(self), geolocation=(), microphone=()'
 	);
 	response.headers.delete('access-control-allow-origin');
 	return response;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './accordion';
-export * from './navbar';
 export * from './forms';
+export * from './navbar';
+export * from './video';
 export { default as Alert } from './Alert.svelte';
 export { default as BackgroundImage } from './BackgroundImage.svelte';
 export { default as Banner } from './Banner.svelte';

--- a/src/lib/video/CloudflareStreamPlayer.svelte
+++ b/src/lib/video/CloudflareStreamPlayer.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { createEventDispatcher, onDestroy } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
+	import { useCloudflareStream } from './cloudflareStream';
+
+	const dispatchEvent = createEventDispatcher();
+
+	let className = '';
+	export { className as class };
+	export let code: string;
+	export let videoId: string;
+	export let autoplay = false;
+	export let preload = false;
+	export let loop = false;
+	export let muted = false;
+	export let controls = true;
+	export let primaryColor: string | undefined = undefined;
+	export let poster: string | undefined = undefined;
+	export let playing = false;
+	export let volume = 1;
+	export let duration: number | undefined = undefined;
+	export let currentTime = 0;
+	export let progress: [number, number][] = [];
+
+	let url: URL;
+	$: {
+		url = new URL(`https://customer-${code}.cloudflarestream.com/${videoId}/iframe`);
+		if (autoplay) {
+			url.searchParams.set('autoplay', 'true');
+		}
+		if (preload) {
+			url.searchParams.set('preload', 'true');
+		}
+		if (loop) {
+			url.searchParams.set('loop', 'true');
+		}
+		if (muted) {
+			url.searchParams.set('muted', 'true');
+		}
+		url.searchParams.set('controls', controls.toString());
+		if (primaryColor) {
+			url.searchParams.set('primaryColor', primaryColor);
+		}
+		if (poster) {
+			url.searchParams.set('poster', poster);
+		}
+	}
+
+	let videoElement: HTMLIFrameElement | undefined = undefined;
+	const Stream = useCloudflareStream();
+	$: player = videoElement && $Stream ? $Stream(videoElement) : null;
+
+	$: if (player) {
+		player.volume = volume;
+	}
+	$: if (player && player.currentTime !== currentTime) {
+		player.currentTime = currentTime;
+	}
+
+	$: if (player) {
+		player.addEventListener('play', onPlay);
+		player.addEventListener('pause', onPause);
+		player.addEventListener('ended', onEnded);
+		player.addEventListener('timeupdate', onTimeUpdate);
+		player.addEventListener('durationchange', onDurationChange);
+		player.addEventListener('progress', onProgress);
+	}
+	onDestroy(() => {
+		if (player) {
+			player.removeEventListener('play', onPlay);
+			player.removeEventListener('pause', onPause);
+			player.removeEventListener('ended', onEnded);
+			player.removeEventListener('timeupdate', onTimeUpdate);
+			player.removeEventListener('durationchange', onDurationChange);
+			player.removeEventListener('progress', onProgress);
+		}
+	});
+
+	function onPlay() {
+		dispatchEvent('play');
+		playing = true;
+	}
+	function onPause() {
+		dispatchEvent('pause');
+		playing = false;
+	}
+	function onEnded() {
+		dispatchEvent('ended');
+	}
+	function onTimeUpdate() {
+		if (!player) return;
+		currentTime = player.currentTime;
+		dispatchEvent('timeupdate', currentTime);
+	}
+	function onDurationChange() {
+		if (!player) return;
+		duration = player.duration;
+		dispatchEvent('durationchange', duration);
+	}
+	function onProgress() {
+		if (!player) return;
+
+		const ranges = player.buffered;
+		const buffered: [number, number][] = [];
+		for (let i = 0; i < ranges.length; i++) {
+			buffered.push([ranges.start(i), ranges.end(i)]);
+		}
+		progress = buffered;
+		dispatchEvent('progress', progress);
+	}
+
+	export function play() {
+		if (!player) {
+			return;
+		}
+
+		player.play();
+	}
+	export function pause() {
+		if (!player) {
+			return;
+		}
+
+		player.pause();
+	}
+</script>
+
+<iframe
+	bind:this={videoElement}
+	class={twMerge('h-full w-full bg-black', className)}
+	src={url.toString()}
+	allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+	title="Video Player"
+/>

--- a/src/lib/video/FullscreenButton.svelte
+++ b/src/lib/video/FullscreenButton.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import MaximiseIcon from './icons/MaximiseIcon.svelte';
+	import MinimizeIcon from './icons/MinimizeIcon.svelte';
+
+	export let fullscreen = false;
+	export let element: HTMLElement | undefined;
+
+	function toggleFullscreen() {
+		if (document.fullscreenElement) {
+			document.exitFullscreen();
+		} else {
+			element?.requestFullscreen({ navigationUI: 'hide' });
+		}
+	}
+</script>
+
+<svelte:window on:fullscreenchange={() => (fullscreen = !!document.fullscreenElement)} />
+
+<button class="p-1" on:click={toggleFullscreen}>
+	{#if fullscreen}
+		<MinimizeIcon />
+	{:else}
+		<MaximiseIcon />
+	{/if}
+</button>

--- a/src/lib/video/HorizontalRange.svelte
+++ b/src/lib/video/HorizontalRange.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	const dispatchEvent = createEventDispatcher();
+
+	let className = '';
+	export { className as class };
+	export let max = 1;
+	export let value = 0;
+	export let highlightRanges: [number, number][] = [];
+	export let disabled = false;
+
+	let scrubbing = false;
+	export let scrubValue = 0;
+	let trackWidth = 0;
+
+	$: if (!scrubbing) {
+		scrubValue = value;
+	}
+</script>
+
+<div class={twMerge('relative flex items-center', className)}>
+	<div class="absolute inset-x-0 h-1 rounded-full bg-white/20" bind:clientWidth={trackWidth} />
+	{#each highlightRanges as [start, end]}
+		<div
+			class="absolute left-0 h-1 rounded-full bg-white/50"
+			style:left="{(start / max) * trackWidth}px"
+			style:width="{((end - start) / max) * trackWidth}px"
+		/>
+	{/each}
+	<div
+		class="absolute left-0 h-1 rounded-full bg-primary-600"
+		style:width="{(scrubValue / max) * trackWidth}px"
+	/>
+	<input
+		type="range"
+		class="z-10 w-full appearance-none bg-transparent [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary-600 [&::-webkit-slider-thumb]:shadow-md [&:disabled::-webkit-slider-thumb]:bg-gray-400"
+		step="any"
+		min="0"
+		{max}
+		{disabled}
+		bind:value={scrubValue}
+		on:input={() => {
+			scrubbing = true;
+		}}
+		on:change={() => {
+			scrubbing = false;
+			value = scrubValue;
+			dispatchEvent('change', scrubValue);
+		}}
+	/>
+</div>

--- a/src/lib/video/ScrubBar.svelte
+++ b/src/lib/video/ScrubBar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import HorizontalRange from './HorizontalRange.svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	const dispatchEvent = createEventDispatcher();
+
+	let className: string | undefined = undefined;
+	export { className as class };
+	export let duration: number | undefined = undefined;
+	export let currentTime: number;
+	export let buffered: [number, number][] = [];
+
+	let scrubTime = 0;
+
+	function formatSeconds(secs: number) {
+		const minutes = Math.floor(secs / 60);
+		const seconds = Math.round(secs % 60)
+			.toString()
+			.padStart(2, '0');
+		return `${minutes}:${seconds}`;
+	}
+</script>
+
+<div class={twMerge('flex items-center gap-6', className)}>
+	<HorizontalRange
+		class="grow"
+		max={duration}
+		value={currentTime}
+		highlightRanges={buffered}
+		disabled={duration === undefined}
+		bind:scrubValue={scrubTime}
+		on:change={(evt) => {
+			dispatchEvent('seek', evt.detail);
+		}}
+	/>
+	{#if duration}
+		<div class="font-mono">{formatSeconds(scrubTime)} / {formatSeconds(duration)}</div>
+	{/if}
+</div>

--- a/src/lib/video/VerticalRange.svelte
+++ b/src/lib/video/VerticalRange.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	export let value = 0;
+	export let min = 0;
+	export let max = 1;
+
+	let trackHeight = 1;
+</script>
+
+<div class="relative flex h-32 w-5 items-center justify-center">
+	<div class="absolute inset-y-0 w-1 rounded-full bg-white/20" bind:clientHeight={trackHeight} />
+	<div
+		class="absolute bottom-0 w-1 rounded-full bg-primary-600"
+		style:height="{(value / max) * trackHeight}px"
+	/>
+	<input
+		type="range"
+		{min}
+		{max}
+		step="any"
+		bind:value
+		class="h-1 w-40 -rotate-90 appearance-none bg-transparent [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary-600 [&::-webkit-slider-thumb]:shadow-md"
+	/>
+</div>

--- a/src/lib/video/VideoPlayer.svelte
+++ b/src/lib/video/VideoPlayer.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { twJoin, twMerge } from 'tailwind-merge';
+	import debounce from 'just-debounce-it';
+	import PauseIcon from './icons/PauseIcon.svelte';
+	import PlayIcon from './icons/PlayIcon.svelte';
+
+	const dispatchEvent = createEventDispatcher();
+
+	let className = '';
+	export { className as class };
+	export let element: HTMLElement | undefined = undefined;
+	export let playing = false;
+	export let forceControls = false;
+
+	let interacting = false;
+	$: showControls = !playing || interacting || forceControls;
+
+	$: if (!showControls) {
+		dispatchEvent('hideControls');
+	}
+
+	const stopInteracting = debounce(() => {
+		interacting = false;
+	}, 2000);
+	function startInteracting() {
+		interacting = true;
+		stopInteracting();
+	}
+</script>
+
+<div
+	bind:this={element}
+	class={twMerge(
+		'relative overflow-hidden bg-black text-white',
+		!showControls && 'cursor-none',
+		className
+	)}
+	on:pointermove={startInteracting}
+	on:pointerdown={startInteracting}
+	on:pointerleave={() => (interacting = false)}
+>
+	<!-- Video element -->
+	<div class="pointer-events-none absolute inset-0 h-full w-full">
+		<slot />
+	</div>
+
+	<!-- Controls overlay -->
+	<div
+		class={twJoin(
+			'absolute inset-0 bg-gradient-to-b from-black/75 via-transparent to-black/75 transition duration-300',
+			!showControls && 'pointer-events-none opacity-0'
+		)}
+	>
+		<button
+			class="absolute inset-0 flex cursor-default items-center justify-center"
+			on:click={() => (playing ? dispatchEvent('pause') : dispatchEvent('play'))}
+		>
+			<div class="cursor-pointer rounded-full bg-black/50 p-4 text-center">
+				{#if playing}
+					<PauseIcon class="h-12 w-12 drop-shadow" />
+				{:else}
+					<PlayIcon class="h-12 w-12 drop-shadow" />
+				{/if}
+			</div>
+		</button>
+
+		<!-- Top controls -->
+		<div
+			class={twMerge(
+				'relative z-10 w-full p-6 px-12 transition duration-300',
+				!showControls && '-translate-y-full'
+			)}
+		>
+			<slot name="top" />
+		</div>
+
+		<!-- Bottom controls -->
+		<div
+			class={twMerge(
+				'absolute bottom-0 w-full px-12 py-6 transition duration-300',
+				!showControls && 'translate-y-full'
+			)}
+		>
+			<slot name="bottom" />
+		</div>
+
+		<div class="pointer-events-none absolute inset-0">
+			<slot name="overlay" />
+		</div>
+	</div>
+</div>

--- a/src/lib/video/VolumeControl.svelte
+++ b/src/lib/video/VolumeControl.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import VerticalRange from './VerticalRange.svelte';
+	import VolumeFullIcon from './icons/VolumeFullIcon.svelte';
+	import VolumeMuteIcon from './icons/VolumeMuteIcon.svelte';
+
+	export let volume = 1;
+	let restoreVolume = 1;
+</script>
+
+<div class="group/volume relative flex items-center justify-center">
+	<div class="absolute bottom-8 z-10 hidden p-10 pb-2 group-hover/volume:block">
+		<div
+			class="flex items-center justify-center rounded-lg border border-white/10 bg-black/70 px-2 py-3 shadow-lg backdrop-blur"
+		>
+			<VerticalRange bind:value={volume} />
+		</div>
+	</div>
+	<button
+		class="p-1"
+		on:click={() => {
+			if (volume > 0) {
+				restoreVolume = volume;
+				volume = 0;
+			} else {
+				volume = restoreVolume || 1;
+			}
+		}}
+	>
+		{#if volume > 0}
+			<VolumeFullIcon />
+		{:else}
+			<VolumeMuteIcon />
+		{/if}
+	</button>
+</div>

--- a/src/lib/video/cloudflareStream.ts
+++ b/src/lib/video/cloudflareStream.ts
@@ -1,0 +1,31 @@
+import { browser } from '$app/environment';
+import { onMount } from 'svelte';
+import { get, readonly, writable } from 'svelte/store';
+
+const sdkScriptLocation = 'https://embed.cloudflarestream.com/embed/sdk.latest.js';
+export function useCloudflareStream() {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const streamSdk = writable(browser ? (window as any).Stream : undefined);
+
+	onMount(() => {
+		const existingSdk = get(streamSdk);
+		if (existingSdk) {
+			return;
+		}
+
+		const existingScript = document.querySelector<HTMLScriptElement>(
+			`script[src='${sdkScriptLocation}']`
+		);
+		const script = existingScript ?? document.createElement('script');
+		script.addEventListener('load', () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			streamSdk.set((window as any).Stream);
+		});
+		if (!existingScript) {
+			script.src = sdkScriptLocation;
+			document.head.appendChild(script);
+		}
+	});
+
+	return readonly(streamSdk);
+}

--- a/src/lib/video/icons/MaximiseIcon.svelte
+++ b/src/lib/video/icons/MaximiseIcon.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path d="M3 3H9V5H5V9H3V3Z" fill="currentColor" />
+	<path d="M3 21H9V19H5V15H3V21Z" fill="currentColor" />
+	<path d="M15 21H21V15H19V19H15V21Z" fill="currentColor" />
+	<path d="M21 3H15V5H19V9H21V3Z" fill="currentColor" />
+</svg>

--- a/src/lib/video/icons/MinimizeIcon.svelte
+++ b/src/lib/video/icons/MinimizeIcon.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path d="M9 9H3V7H7V3H9V9Z" fill="currentColor" />
+	<path d="M9 15H3V17H7V21H9V15Z" fill="currentColor" />
+	<path d="M21 15H15V21H17V17H21V15Z" fill="currentColor" />
+	<path d="M15 9.00012H21V7.00012H17V3.00012H15V9.00012Z" fill="currentColor" />
+</svg>

--- a/src/lib/video/icons/PauseIcon.svelte
+++ b/src/lib/video/icons/PauseIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="currentColor"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path
+		fill-rule="evenodd"
+		d="M6.75 5.25a.75.75 0 01.75-.75H9a.75.75 0 01.75.75v13.5a.75.75 0 01-.75.75H7.5a.75.75 0 01-.75-.75V5.25zm7.5 0A.75.75 0 0115 4.5h1.5a.75.75 0 01.75.75v13.5a.75.75 0 01-.75.75H15a.75.75 0 01-.75-.75V5.25z"
+		clip-rule="evenodd"
+	/>
+</svg>

--- a/src/lib/video/icons/PlayIcon.svelte
+++ b/src/lib/video/icons/PlayIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill="currentColor"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path
+		fill-rule="evenodd"
+		d="M4.5 5.653c0-1.426 1.529-2.33 2.779-1.643l11.54 6.348c1.295.712 1.295 2.573 0 3.285L7.28 19.991c-1.25.687-2.779-.217-2.779-1.643V5.653z"
+		clip-rule="evenodd"
+	/>
+</svg>

--- a/src/lib/video/icons/VolumeFullIcon.svelte
+++ b/src/lib/video/icons/VolumeFullIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	stroke="currentColor"
+	stroke-width="1.5"
+	fill="none"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z"
+	/>
+</svg>

--- a/src/lib/video/icons/VolumeMuteIcon.svelte
+++ b/src/lib/video/icons/VolumeMuteIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	let className = '';
+	export { className as class };
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	stroke="currentColor"
+	stroke-width="1.5"
+	fill="none"
+	class={twMerge('h-6 w-6', className)}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M17.25 9.75L19.5 12m0 0l2.25 2.25M19.5 12l2.25-2.25M19.5 12l-2.25 2.25m-10.5-6l4.72-4.72a.75.75 0 011.28.531V19.94a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.506-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.395C2.806 8.757 3.63 8.25 4.51 8.25H6.75z"
+	/>
+</svg>

--- a/src/lib/video/index.ts
+++ b/src/lib/video/index.ts
@@ -1,0 +1,6 @@
+export * from './cloudflareStream';
+export { default as CloudflareStreamPlayer } from './CloudflareStreamPlayer.svelte';
+export { default as FullscreenButton } from './FullscreenButton.svelte';
+export { default as ScrubBar } from './ScrubBar.svelte';
+export { default as VideoPlayer } from './VideoPlayer.svelte';
+export { default as VolumeControl } from './VolumeControl.svelte';

--- a/src/routes/(docs)/+layout.svelte
+++ b/src/routes/(docs)/+layout.svelte
@@ -29,7 +29,8 @@
 		{ name: 'TextInput' },
 		{ name: 'TextArea' },
 		{ name: 'TitleDescription' },
-		{ name: 'Tooltip' }
+		{ name: 'Tooltip' },
+		{ name: 'VideoPlayer' }
 	];
 </script>
 

--- a/src/routes/(docs)/VideoPlayer/+page.svelte
+++ b/src/routes/(docs)/VideoPlayer/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import ExamplePage from '../ExamplePage.svelte';
+	import ExampleVideoPlayer from './ExampleVideoPlayer.svelte';
+	import usage from './ExampleVideoPlayer.svelte?raw';
+</script>
+
+<ExamplePage title="Video Player" {usage}>
+	<ExampleVideoPlayer />
+</ExamplePage>

--- a/src/routes/(docs)/VideoPlayer/ExampleVideoPlayer.svelte
+++ b/src/routes/(docs)/VideoPlayer/ExampleVideoPlayer.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import {
+		CloudflareStreamPlayer,
+		FullscreenButton,
+		ScrubBar,
+		VideoPlayer,
+		VolumeControl
+	} from '$lib';
+
+	let playerElement: HTMLElement | undefined = undefined;
+	let playing = false;
+	let player: CloudflareStreamPlayer;
+	let volume = 1;
+	let duration: number | undefined = undefined;
+	let currentTime = 0;
+	let buffered: [number, number][] = [];
+</script>
+
+<VideoPlayer
+	bind:element={playerElement}
+	class="h-[400px] w-[600px]"
+	{playing}
+	on:play={() => player.play()}
+	on:pause={() => player.pause()}
+>
+	<div slot="top">
+		<h2 class="text-center text-lg">Big Buck Bunny</h2>
+	</div>
+
+	<CloudflareStreamPlayer
+		bind:this={player}
+		code="j8h7q0ly0igrpwgg"
+		videoId="4920d2fd1fde191adfda65f3b7453282"
+		preload
+		controls={false}
+		{volume}
+		bind:playing
+		bind:duration
+		bind:currentTime
+		bind:progress={buffered}
+	/>
+
+	<div slot="bottom" class="flex items-center gap-6">
+		<ScrubBar
+			class="grow"
+			{currentTime}
+			{duration}
+			{buffered}
+			on:seek={(evt) => (currentTime = evt.detail)}
+		/>
+		<VolumeControl bind:volume />
+		<FullscreenButton element={playerElement} />
+	</div>
+</VideoPlayer>

--- a/static/_headers
+++ b/static/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Cross-Origin-Resource-Policy: same-origin
-  Permissions-Policy: camera=(), display-capture=(), fullscreen=(), geolocation=(), microphone=()
+  Permissions-Policy: camera=(), display-capture=(), fullscreen=(self), geolocation=(), microphone=()

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,9 +12,12 @@ const config = {
 			mode: 'auto',
 			directives: {
 				// Not able to be strict-dynamic due to https://github.com/sveltejs/kit/issues/3558
-				'default-src': ['self'],
-				'object-src': ['none'],
-				'base-uri': ['none']
+				'script-src': ['self', 'https://embed.cloudflarestream.com/embed/sdk.latest.js'],
+				'style-src': [
+					'self',
+					// bind:clientWidth/Height requires this - https://github.com/sveltejs/svelte/issues/8607
+					'unsafe-inline'
+				]
 			}
 		},
 		adapter: adapter()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ const configureServer = (server: { middlewares: Connect.Server }) => {
 		res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
 		res.setHeader(
 			'Permissions-Policy',
-			'camera=(), display-capture=(), fullscreen=(), geolocation=(), microphone=()'
+			'camera=(), display-capture=(), fullscreen=(self), geolocation=(), microphone=()'
 		);
 		next();
 	});


### PR DESCRIPTION
Adds a video player component and supporting controls.
The component is completely independent of the actual video source, it could be a `<video />` element, or any other embeddable player as long as you can programatically control it.

I have also added a `<CloudflareStreamPlayer />` component. It might be a _little_ out of place in this project and could maybe be published as its own standalone library. It is useful for the example/demo though so I thats why I have added it.