### PR TITLE
fix play/pause and range styling in firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
+		},
+		"./tailwind": {
+			"types": "./dist/tailwind.d.ts",
+			"svelte": "./dist/tailwind.js"
 		}
 	},
 	"files": [

--- a/src/lib/tailwind.ts
+++ b/src/lib/tailwind.ts
@@ -1,0 +1,7 @@
+import plugin from 'tailwindcss/plugin';
+
+export default function () {
+	return plugin(function ({ addVariant }) {
+		addVariant('range-thumb', ['&::-webkit-slider-thumb', '&::-moz-range-thumb']);
+	});
+}

--- a/src/lib/video/HorizontalRange.svelte
+++ b/src/lib/video/HorizontalRange.svelte
@@ -35,7 +35,7 @@
 	/>
 	<input
 		type="range"
-		class="z-10 w-full appearance-none bg-transparent [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary-600 [&::-webkit-slider-thumb]:shadow-md [&:disabled::-webkit-slider-thumb]:bg-gray-400"
+		class="z-10 w-full appearance-none bg-transparent range-thumb:h-5 range-thumb:w-5 range-thumb:appearance-none range-thumb:rounded-full range-thumb:border-none range-thumb:bg-primary-600 range-thumb:shadow-md range-thumb:disabled:bg-gray-400"
 		step="any"
 		min="0"
 		{max}

--- a/src/lib/video/VerticalRange.svelte
+++ b/src/lib/video/VerticalRange.svelte
@@ -18,6 +18,6 @@
 		{max}
 		step="any"
 		bind:value
-		class="h-1 w-40 -rotate-90 appearance-none bg-transparent [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary-600 [&::-webkit-slider-thumb]:shadow-md"
+		class="h-1 w-40 -rotate-90 appearance-none bg-transparent range-thumb:h-5 range-thumb:w-5 range-thumb:appearance-none range-thumb:rounded-full range-thumb:border-none range-thumb:bg-primary-600 range-thumb:shadow-md"
 	/>
 </div>

--- a/src/lib/video/VideoPlayer.svelte
+++ b/src/lib/video/VideoPlayer.svelte
@@ -53,7 +53,7 @@
 		)}
 	>
 		<button
-			class="absolute inset-0 flex cursor-default items-center justify-center"
+			class="absolute inset-0 flex w-full cursor-default items-center justify-center"
 			on:click={() => (playing ? dispatchEvent('pause') : dispatchEvent('play'))}
 		>
 			<div class="cursor-pointer rounded-full bg-black/50 p-4 text-center">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import colors from 'tailwindcss/colors';
+import ppSvelteComponents from './src/lib/tailwind';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -11,5 +12,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require('@tailwindcss/typography')]
+	plugins: [require('@tailwindcss/typography'), ppSvelteComponents()]
 };


### PR DESCRIPTION
Adds a tailwind plugin for styling the range-thumb that makes it easier to cater for both webkit and firefox - it seems likely we would want to add other utilities in the future and other frameworks also have tailwind plugins so it seems reasonable.