### PR TITLE
move resize listener up to avoid false warning about throttle

### DIFF
--- a/src/lib/Carousel.svelte
+++ b/src/lib/Carousel.svelte
@@ -95,6 +95,14 @@
 	function isInRange(range: [number, number], value: number): boolean {
 		return value >= range[0] && value <= range[1];
 	}
+
+	const onResize = throttle(() => {
+		if (!containerEl) {
+			return;
+		}
+		updateCachedValues(containerEl);
+		updateItemIndex((index) => index);
+	}, 300);
 </script>
 
 <svelte:window
@@ -108,13 +116,7 @@
 	}}
 	on:pointerup={stopDragging}
 	on:pointercancel={stopDragging}
-	on:resize={throttle(() => {
-		if (!containerEl) {
-			return;
-		}
-		updateCachedValues(containerEl);
-		updateItemIndex((index) => index);
-	}, 300)}
+	on:resize={onResize}
 />
 
 <ul


### PR DESCRIPTION
I'm guessing theres some subtle tree shaking bug when using it inline which means that import gets kept in on server builds of the component. Moving the use of throttle to within the script block seems to fix it.

Fixes #290
