### PR TITLE
explicitly give tag name to create gh release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,3 +127,4 @@ jobs:
         uses: mikepenz/action-gh-release@v0.2.0-a03
         with:
           body: ${{steps.github_release.outputs.changelog}}
+          tag_name: 'v${{ steps.publish.outputs.version }}'


### PR DESCRIPTION
recent release failed to push the changelog as it doesn't know what tag to associate the release with