### PR TITLE
fix export of tailwind plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		},
 		"./tailwind": {
 			"types": "./dist/tailwind.d.ts",
-			"svelte": "./dist/tailwind.js"
+			"default": "./dist/tailwind.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
This was incorrectly tagged as a svelte specific export causing it to be unimportable in node.