### PR TITLE
fire dismiss event on banner instead of hiding itself

### DIFF
--- a/src/lib/banner/Banner.svelte
+++ b/src/lib/banner/Banner.svelte
@@ -4,7 +4,7 @@
 	import { Button } from '$lib';
 	import { createEventDispatcher } from 'svelte';
 
-	type $$Props = SvelteHTMLElements['section'] & { dismissable: boolean };
+	type $$Props = SvelteHTMLElements['section'] & { dismissable?: boolean };
 
 	const dispatch = createEventDispatcher<{ dismiss: never }>();
 

--- a/src/lib/banner/Banner.svelte
+++ b/src/lib/banner/Banner.svelte
@@ -2,32 +2,34 @@
 	import type { SvelteHTMLElements } from 'svelte/elements';
 	import { twMerge } from 'tailwind-merge';
 	import { Button } from '$lib';
+	import { createEventDispatcher } from 'svelte';
 
-	type $$Props = SvelteHTMLElements['section'];
+	type $$Props = SvelteHTMLElements['section'] & { dismissable: boolean };
+
+	const dispatch = createEventDispatcher<{ dismiss: never }>();
 
 	let className: $$Props['class'] = undefined;
 	export { className as class };
-
-	let showBanner = true;
+	export let dismissable = false;
 </script>
 
-{#if showBanner}
-	<section
-		class={twMerge(
-			'mx-auto max-w-screen-2xl items-center justify-between gap-4 bg-white p-2 shadow-sm sm:p-4 md:flex',
-			className
-		)}
-		{...$$restProps}
-	>
-		<slot />
+<section
+	class={twMerge(
+		'mx-auto max-w-screen-2xl items-center justify-between gap-4 bg-white p-2 shadow-sm sm:p-4 md:flex',
+		className
+	)}
+	{...$$restProps}
+>
+	<slot />
+	{#if dismissable}
 		<Button
 			variant="secondary"
 			class="h-12 max-md:my-2 max-md:w-full"
-			on:click={() => (showBanner = false)}
+			on:click={() => dispatch('dismiss')}
 		>
 			<span aria-hidden="true" class="max-md:hidden">&times;</span>
 			<span aria-hidden="true" class="md:hidden">Dismiss</span>
 			<span class="sr-only">Close banner</span>
 		</Button>
-	</section>
-{/if}
+	{/if}
+</section>

--- a/src/lib/banner/Banner.test.ts
+++ b/src/lib/banner/Banner.test.ts
@@ -1,6 +1,6 @@
 import TestBanner from './TestBanner.svelte';
-import { test, expect, afterEach } from 'vitest';
-import { cleanup, fireEvent, render, waitForElementToBeRemoved } from '@testing-library/svelte';
+import { test, expect, afterEach, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
 
 afterEach(cleanup);
 
@@ -15,14 +15,11 @@ test('should render everything', () => {
 	expect(primaryAction.getAttribute('href')).toBe('https://peopleplus.co.uk');
 });
 
-test('should dismiss the banner once clicked', async () => {
-	const { getByText, queryByText } = render(TestBanner);
-	getByText('Banner Title');
-
+test('should trigger dismiss event once clicked', async () => {
+	const { component, getByText } = render(TestBanner);
 	const dismissButton = getByText('Dismiss');
+	const dismiss = vi.fn();
+	component.$on('dismiss', dismiss);
 	fireEvent.click(dismissButton);
-
-	await waitForElementToBeRemoved(() => queryByText('Banner Title'));
-
-	expect(queryByText('Banner Title')).to.not.exist;
+	expect(dismiss).toHaveBeenCalledOnce();
 });

--- a/src/lib/banner/TestBanner.svelte
+++ b/src/lib/banner/TestBanner.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
 	import Banner from '$lib/banner/Banner.svelte';
 	import { Button, Typography } from '$lib';
 </script>
 
-<Banner>
+<Banner dismissable on:dismiss>
 	<div class="items-center gap-4 md:flex">
 		<div class="space-y-1 max-sm:pb-2">
 			<Typography variant="sub-heading">Banner Title</Typography>

--- a/src/routes/(docs)/Banner/ExampleBanner.svelte
+++ b/src/routes/(docs)/Banner/ExampleBanner.svelte
@@ -1,25 +1,28 @@
-<script>
+<script lang="ts">
 	import { Button, Typography, Banner } from '$lib';
+	let showBanner = true;
 </script>
 
-<Banner>
-	<div class="items-center gap-4 md:flex">
-		<div class="relative h-28 rounded-lg md:h-40 md:w-80 lg:h-20 lg:w-64">
-			<img
-				src="/jumbotron.jpg"
-				alt=""
-				class="inset-0 h-full w-full rounded-lg object-cover object-center"
-			/>
+{#if showBanner}
+	<Banner dismissable on:dismiss={() => (showBanner = false)}>
+		<div class="items-center gap-4 md:flex">
+			<div class="relative h-28 rounded-lg md:h-40 md:w-80 lg:h-20 lg:w-64">
+				<img
+					src="/jumbotron.jpg"
+					alt=""
+					class="inset-0 h-full w-full rounded-lg object-cover object-center"
+				/>
+			</div>
+			<div class="space-y-1 max-sm:pb-2">
+				<Typography variant="sub-heading">'The Lyrics, The Music & The Money'</Typography>
+				<Typography variant="body">
+					Introducing our latest course! Unravel the complex world of music industry economics and
+					understand the artistry behind creating impactful lyrics.
+				</Typography>
+			</div>
+			<Button href="https://peopleplus.co.uk" class="h-12 w-full md:w-1/2 lg:w-1/4">
+				View Course
+			</Button>
 		</div>
-		<div class="space-y-1 max-sm:pb-2">
-			<Typography variant="sub-heading">'The Lyrics, The Music & The Money'</Typography>
-			<Typography variant="body">
-				Introducing our latest course! Unravel the complex world of music industry economics and
-				understand the artistry behind creating impactful lyrics.
-			</Typography>
-		</div>
-		<Button href="https://peopleplus.co.uk" class="h-12 w-full md:w-1/2 lg:w-1/4">
-			View Course
-		</Button>
-	</div>
-</Banner>
+	</Banner>
+{/if}


### PR DESCRIPTION
I think it makes more sense for the actual hiding of the banner to be handled externally to the banner component itself.
This PR changes the dismiss button to fire the `dismiss` event instead of hide the banner itself. This way the consumer of the component can choose how the banner gets hidden and can react to the dismiss by, for example, adding a cookie, or showing a different banner etc.