### PR TITLE
move lucide-svelte to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"esm-env": "^1.0.0",
 				"just-debounce-it": "^3.2.0",
 				"just-throttle": "^4.2.0",
+				"lucide-svelte": "^0.258.0",
 				"svelte-headlessui": "^0.0.18",
 				"tailwind-merge": "^1.12.0"
 			},
@@ -33,7 +34,6 @@
 				"eslint-plugin-svelte3": "^4.0.0",
 				"istanbul": "^0.4.5",
 				"jsdom": "^22.0.0",
-				"lucide-svelte": "^0.258.0",
 				"nyc": "^15.1.0",
 				"playwright-test-coverage": "^1.2.12",
 				"postcss": "^8.4.21",
@@ -5294,7 +5294,6 @@
 			"version": "0.258.0",
 			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.258.0.tgz",
 			"integrity": "sha512-rb31yWJA86A0kvKLlBtDtCThXUETR+XQU6zMrrhF0NStmX3Pg0BCz5E7dwsE3Q59BhY4LvyrTOruwEo/G1BrZA==",
-			"dev": true,
 			"peerDependencies": {
 				"svelte": ">=3 <5"
 			}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"esm-env": "^1.0.0",
 		"just-debounce-it": "^3.2.0",
 		"just-throttle": "^4.2.0",
+		"lucide-svelte": "^0.258.0",
 		"svelte-headlessui": "^0.0.18",
 		"tailwind-merge": "^1.12.0"
 	},
@@ -70,7 +71,6 @@
 		"eslint-plugin-svelte3": "^4.0.0",
 		"istanbul": "^0.4.5",
 		"jsdom": "^22.0.0",
-		"lucide-svelte": "^0.258.0",
 		"nyc": "^15.1.0",
 		"playwright-test-coverage": "^1.2.12",
 		"postcss": "^8.4.21",


### PR DESCRIPTION
This was erroneously in the dev dependencies meaning that when installing in a new project that isn't already using lucide-svelte the module would not be found.