### PR TITLE
make use property optional on input label

### DIFF
--- a/src/lib/forms/InputLabel.svelte
+++ b/src/lib/forms/InputLabel.svelte
@@ -3,7 +3,7 @@
 	import type { HTMLLabelAttributes } from 'svelte/elements';
 	import { twMerge } from 'tailwind-merge';
 
-	type $$Props = HTMLLabelAttributes & { use: UseActions };
+	type $$Props = HTMLLabelAttributes & { use?: UseActions };
 
 	let className: $$Props['class'] = undefined;
 	export { className as class };


### PR DESCRIPTION
the use property was erroneously marked as required on the InputLabel component, this fixes that.