### PR TITLE
update to only support svelte v4, closes #354

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,11 @@
 				"playwright-test-coverage": "^1.2.12",
 				"postcss": "^8.4.21",
 				"prettier": "^2.8.8",
-				"prettier-plugin-svelte": "^2.8.1",
+				"prettier-plugin-svelte": "^2.10.1",
 				"prettier-plugin-tailwindcss": "^0.3.0",
 				"publint": "^0.1.9",
-				"svelte": "^3.54.0",
-				"svelte-check": "^3.0.1",
+				"svelte": "^4.0.5",
+				"svelte-check": "^3.4.6",
 				"tailwindcss": "^3.3.2",
 				"tslib": "^2.6.0",
 				"typescript": "^5.1.6",
@@ -54,7 +54,7 @@
 				"wrangler": "^3.2.0"
 			},
 			"peerDependencies": {
-				"svelte": "^3.54.0 || ^4.0.0"
+				"svelte": "^4.0.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -88,7 +88,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -1221,7 +1220,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1235,7 +1233,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1244,7 +1241,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1252,14 +1248,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.18",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
 			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -1268,8 +1262,7 @@
 		"node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -1575,6 +1568,11 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
 			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
 			"dev": true
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
@@ -2083,7 +2081,6 @@
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
 			"integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2337,6 +2334,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/axobject-query": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+			"dependencies": {
+				"dequal": "^2.0.3"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -2717,6 +2722,26 @@
 				"wrap-ansi": "^6.2.0"
 			}
 		},
+		"node_modules/code-red": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.3.tgz",
+			"integrity": "sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.14",
+				"@types/estree": "^1.0.0",
+				"acorn": "^8.8.2",
+				"estree-walker": "^3.0.3",
+				"periscopic": "^3.1.0"
+			}
+		},
+		"node_modules/code-red/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2795,6 +2820,18 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/css.escape": {
@@ -3003,6 +3040,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -4584,6 +4629,14 @@
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true
 		},
+		"node_modules/is-reference": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
+			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
 		"node_modules/is-regex": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -5312,6 +5365,11 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/locate-character": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5405,7 +5463,6 @@
 			"version": "0.30.1",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.1.tgz",
 			"integrity": "sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
@@ -5436,6 +5493,11 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -6204,6 +6266,24 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/periscopic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
+			}
+		},
+		"node_modules/periscopic/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/picocolors": {
@@ -7348,7 +7428,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7614,11 +7693,26 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.59.2",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-			"integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.5.tgz",
+			"integrity": "sha512-PHKPWP1wiWHBtsE57nCb8xiWB3Ht7/3Kvi3jac0XIxUM2rep8alO7YoAtgWeGD7++tFy46krilOrPW0mG3Dx+A==",
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"acorn": "^8.9.0",
+				"aria-query": "^5.3.0",
+				"axobject-query": "^3.2.1",
+				"code-red": "^1.0.3",
+				"css-tree": "^2.3.1",
+				"estree-walker": "^3.0.3",
+				"is-reference": "^3.0.1",
+				"locate-character": "^3.0.0",
+				"magic-string": "^0.30.0",
+				"periscopic": "^3.1.0"
+			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16"
 			}
 		},
 		"node_modules/svelte-check": {
@@ -7804,6 +7898,22 @@
 			"integrity": "sha512-BN8XDA7dKyuh+Lmdn3vxCzJd3M7L4BLdRziIAJew2AiBFMcrJJg8srEMYYoTCOLtYJ2Oqlv3+3/K5b6uHM8LSg==",
 			"peerDependencies": {
 				"svelte": "^3.59.1 || ^4.0.0"
+			}
+		},
+		"node_modules/svelte/node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/svelte/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/svelte2tsx": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"tailwind-merge": "^1.13.0"
 	},
 	"peerDependencies": {
-		"svelte": "^3.54.0 || ^4.0.0"
+		"svelte": "^4.0.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230511.0",
@@ -77,11 +77,11 @@
 		"playwright-test-coverage": "^1.2.12",
 		"postcss": "^8.4.21",
 		"prettier": "^2.8.8",
-		"prettier-plugin-svelte": "^2.8.1",
+		"prettier-plugin-svelte": "^2.10.1",
 		"prettier-plugin-tailwindcss": "^0.3.0",
 		"publint": "^0.1.9",
-		"svelte": "^3.54.0",
-		"svelte-check": "^3.0.1",
+		"svelte": "^4.0.5",
+		"svelte-check": "^3.4.6",
 		"tailwindcss": "^3.3.2",
 		"tslib": "^2.6.0",
 		"typescript": "^5.1.6",

--- a/src/lib/Button.svelte
+++ b/src/lib/Button.svelte
@@ -32,6 +32,7 @@
 		variants[variant ?? 'primary'],
 		className
 	)}
+	role={href ? 'link' : 'button'}
 	on:click
 	use:actions={use}
 	{...$$restProps}

--- a/src/lib/Dropdown.svelte
+++ b/src/lib/Dropdown.svelte
@@ -2,7 +2,7 @@
 	let open = false;
 </script>
 
-<div class="inline-block" on:mouseleave={() => (open = false)}>
+<div class="inline-block" on:mouseleave={() => (open = false)} role="group">
 	<button
 		id="dropdownHoverButton"
 		class="inline-flex items-center rounded-lg bg-blue-700 px-4 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"

--- a/src/lib/cookies/CookieConsentBanner.svelte
+++ b/src/lib/cookies/CookieConsentBanner.svelte
@@ -29,7 +29,7 @@
 		'fixed inset-x-0 bottom-0 max-h-[calc(100%-2rem)] overflow-auto border-t border-gray-300 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800',
 		className
 	)}
-	transition:fade|local
+	transition:fade
 >
 	<div class="flex flex-col gap-4 md:flex-row md:items-center">
 		<div class="grow">
@@ -70,7 +70,7 @@
 		</div>
 	</div>
 	{#if expanded}
-		<div transition:slide|local class="max-w-prose" id="consent-content">
+		<div transition:slide class="max-w-prose" id="consent-content">
 			{#if cookiePolicy}
 				<Typography variant="body" class="mt-4">
 					For more detailed information about the cookies we use, see our <a

--- a/src/lib/toaster/Toast.svelte
+++ b/src/lib/toaster/Toast.svelte
@@ -27,8 +27,8 @@
 		toast.kind === 'error' && 'bg-rose-700/70'
 	)}
 	role="alert"
-	in:fly|local={{ x: 300 }}
-	out:slide|local
+	in:fly={{ x: 300 }}
+	out:slide
 	aria-labelledby="toast-{toast.id}-message"
 >
 	{#if toast.kind === 'success'}

--- a/src/lib/video/VideoPlayer.svelte
+++ b/src/lib/video/VideoPlayer.svelte
@@ -38,6 +38,8 @@
 		!showControls && 'cursor-none',
 		className
 	)}
+	role="button"
+	tabindex="-1"
 	on:pointermove={startInteracting}
 	on:mousedown={startInteracting}
 	on:mouseleave={() => (interacting = false)}


### PR DESCRIPTION
Don't see much value in trying to support both v3 and v4 when afaik we are the only consumer at the moment.