### PR TITLE
use custom test fixture in toaster tests to fix flakiness

### DIFF
--- a/playwright_tests/Toaster.spec.ts
+++ b/playwright_tests/Toaster.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from 'playwright-test-coverage';
+import { expect } from 'playwright-test-coverage';
+import { test } from './fixtures';
 
 const TIMEOUT_MESSAGE = 'Changes successfully saved.';
 const NULL_TIMEOUT_MESSAGE = 'Uploading videos.';


### PR DESCRIPTION
updates toaster test to use the modified version of goto that we use elsewhere that will wait for svelte to have hydrated the page before finishing.