### PR TITLE
add support for bind:group on Switch component

### DIFF
--- a/src/lib/forms/Switch.svelte
+++ b/src/lib/forms/Switch.svelte
@@ -6,6 +6,7 @@
 
 	type $$Props = Omit<HTMLInputAttributes, 'type' | 'role' | `${string}:${string}`> & {
 		use?: UseActions;
+		group?: string[];
 	};
 
 	const dispatch = createEventDispatcher<{ change: boolean }>();
@@ -14,6 +15,7 @@
 	export { className as class };
 	export let checked: $$Props['checked'] = undefined;
 	export let use: UseActions = [];
+	export let group: string[] = [];
 </script>
 
 <input
@@ -25,6 +27,13 @@
 	)}
 	bind:checked
 	use:actions={use}
-	on:change={(evt) => dispatch('change', evt.currentTarget.checked)}
+	on:change={(evt) => {
+		if (evt.currentTarget.checked) {
+			group = [...group, evt.currentTarget.value];
+		} else {
+			group = group.filter((item) => item !== evt.currentTarget.value);
+		}
+		dispatch('change', evt.currentTarget.checked);
+	}}
 	{...$$restProps}
 />

--- a/src/routes/(docs)/Switch/ExampleSwitch.svelte
+++ b/src/routes/(docs)/Switch/ExampleSwitch.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import { InputLabel, Switch } from '$lib';
+	import Typography from '$lib/Typography.svelte';
+
+	let group: string[] = [];
 </script>
 
 <div class="w-60 space-y-2">
@@ -16,5 +19,22 @@
 	<div class="flex items-center justify-between">
 		<InputLabel for="example3">Disabled Unchecked</InputLabel>
 		<Switch name="example3" id="example3" disabled />
+	</div>
+
+	<div class="space-y-2 pt-4">
+		<Typography variant="caption">Example with bind:group</Typography>
+		<div class="flex items-center justify-between">
+			<InputLabel for="a">A</InputLabel>
+			<Switch name="grouped" id="a" value="a" bind:group />
+		</div>
+		<div class="flex items-center justify-between">
+			<InputLabel for="b">B</InputLabel>
+			<Switch name="grouped" id="b" value="b" bind:group />
+		</div>
+		<div class="flex items-center justify-between">
+			<InputLabel for="c">C</InputLabel>
+			<Switch name="grouped" id="c" value="c" bind:group />
+		</div>
+		<pre>Value: {JSON.stringify(group)}</pre>
 	</div>
 </div>


### PR DESCRIPTION
`bind:group` is a little special in svelte so we can't simply pass through the binding like normal so we emulate what bind:group does instead.