### PR TITLE
handle external changes to bind:group in Switch

### DIFF
--- a/src/lib/forms/Switch.svelte
+++ b/src/lib/forms/Switch.svelte
@@ -16,6 +16,10 @@
 	export let checked: $$Props['checked'] = undefined;
 	export let use: UseActions = [];
 	export let group: string[] = [];
+
+	$: if ($$restProps.value != null && group.includes($$restProps.value) !== checked) {
+		checked = group.includes($$restProps.value);
+	}
 </script>
 
 <input
@@ -25,7 +29,7 @@
 		"h-[26px] w-12 cursor-pointer appearance-none rounded-full border border-gray-300 bg-white p-0.5 align-top after:block after:h-5 after:w-5 after:rounded-full after:bg-gray-400 after:transition after:duration-150 after:content-[''] checked:after:translate-x-[1.375rem] checked:after:bg-primary-500 focus:outline-none focus-visible:border-primary-400 focus-visible:ring-1 focus-visible:ring-primary-400 disabled:cursor-default disabled:border-gray-200 disabled:bg-gray-100 disabled:after:bg-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:after:bg-gray-500 dark:checked:after:bg-white dark:disabled:border-gray-700 dark:disabled:bg-gray-800 dark:disabled:after:bg-gray-700",
 		className,
 	)}
-	bind:checked
+	{checked}
 	use:actions={use}
 	on:change={(evt) => {
 		if (evt.currentTarget.checked) {
@@ -33,6 +37,7 @@
 		} else {
 			group = group.filter((item) => item !== evt.currentTarget.value);
 		}
+		checked = evt.currentTarget.checked;
 		dispatch('change', evt.currentTarget.checked);
 	}}
 	{...$$restProps}

--- a/src/routes/(docs)/Switch/ExampleSwitch.svelte
+++ b/src/routes/(docs)/Switch/ExampleSwitch.svelte
@@ -2,7 +2,7 @@
 	import { InputLabel, Switch } from '$lib';
 	import Typography from '$lib/Typography.svelte';
 
-	let group: string[] = [];
+	let group: string[] = ['b'];
 </script>
 
 <div class="w-60 space-y-2">


### PR DESCRIPTION
previous bind:group emulation was not quite complete as it doesn't handle initial values of the group, and external changes to the group. This PR fixes that