### PR TITLE
update active state on side bar item

### DIFF
--- a/.changeset/popular-rats-press.md
+++ b/.changeset/popular-rats-press.md
@@ -1,0 +1,5 @@
+---
+'pp-svelte-components': patch
+---
+
+The SideBarItem active colour is now set to primary colour.

--- a/.changeset/popular-rats-press.md
+++ b/.changeset/popular-rats-press.md
@@ -2,4 +2,4 @@
 'pp-svelte-components': patch
 ---
 
-The SideBarItem active colour is now set to primary colour.
+The SidebarItem active colour is now set to primary colour.

--- a/src/lib/sidebar/SidebarItem.svelte
+++ b/src/lib/sidebar/SidebarItem.svelte
@@ -23,7 +23,7 @@
 		class={twMerge(
 			'flex items-center gap-4 rounded-lg px-3 py-2.5 font-medium text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700',
 			active &&
-				'bg-primary-700 text-white hover:bg-primary-700  active:bg-primary-800 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-700',
+				'bg-primary-700 text-white hover:bg-primary-700 active:bg-primary-800 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-700',
 			className,
 		)}
 		on:click

--- a/src/lib/sidebar/SidebarItem.svelte
+++ b/src/lib/sidebar/SidebarItem.svelte
@@ -23,7 +23,7 @@
 		class={twMerge(
 			'flex items-center gap-4 rounded-lg px-3 py-2.5 font-medium text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700',
 			active &&
-				'bg-gray-200 text-gray-900 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-700',
+				'bg-primary-700 text-white hover:bg-primary-700  active:bg-primary-800 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-700',
 			className,
 		)}
 		on:click


### PR DESCRIPTION
The SideBarItem active colour is now set to the primary colour and keeps the grey background for the hover state.