### PR TITLE
Add a gauge component

### DIFF
--- a/.changeset/fresh-eagles-remain.md
+++ b/.changeset/fresh-eagles-remain.md
@@ -1,0 +1,5 @@
+---
+'pp-svelte-components': patch
+---
+
+Added a Gauge component to use data as a measure of speed or progress towards a goal.

--- a/src/lib/gauge/Gauge.svelte
+++ b/src/lib/gauge/Gauge.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { actions, type UseActions } from '../actions';
+	import { twMerge } from 'tailwind-merge';
+
+	export let className: string | undefined = undefined;
+	export let use: UseActions = [];
+	export let percentage: number | 0;
+	export let leftText: string;
+	export let rightText: string;
+
+	const max = 100;
+	const min = 0;
+	const range = max - min;
+	const gaugeAngle = 180;
+
+	$: percent = (percentage - min) / range;
+	$: needleAngle = gaugeAngle * percent - gaugeAngle / 2;
+</script>
+
+<div class={twMerge('-mb-10 h-52 w-52', className)}>
+	<svg use:actions={use} {...$$restProps} viewBox="0 0 100 100">
+		<defs>
+			<linearGradient id="gaugeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+				<stop offset="0%" style="stop-color:#ff0000;" />
+				<stop offset="50%" style="stop-color:#ffff00;" />
+				<stop offset="100%" style="stop-color:#0de50d;" />
+			</linearGradient>
+		</defs>
+		<path
+			d="M 10,50 A 40,40 0 0 1 90,50"
+			fill="none"
+			stroke="url(#gaugeGradient)"
+			stroke-width="12%"
+			stroke-linecap="round"
+		/>
+		<g
+			class="transition-transform duration-300 ease-in-out"
+			style="transform: rotate({needleAngle}deg); transform-origin: 50% 50%;"
+		>
+			<line
+				x1="50%"
+				y1="22%"
+				x2="50%"
+				y2="18%"
+				class="stroke-slate-900"
+				stroke-width="1.5%"
+				stroke-linecap="round"
+			/>
+
+			<circle
+				cx="50%"
+				cy="10%"
+				r="7%"
+				stroke="#718096"
+				stroke-width="2%"
+				class="fill-white/60 stroke-slate-900"
+			/>
+		</g>
+
+		<text
+			x="50%"
+			y="52.5%"
+			font-size="135%"
+			class="bg-slate-900 place-self-center"
+			class:text-lg={percentage === 100}
+			text-anchor="middle"
+		>
+			{percentage}%
+		</text>
+
+		<text x="0%" y="65%" font-size="40%" class="text-gray-700" text-anchor="start">
+			{leftText}
+		</text>
+
+		<text x="100%" y="65%" font-size="40%" class="text-gray-700" text-anchor="end">
+			{rightText}
+		</text>
+	</svg>
+</div>

--- a/src/lib/gauge/Gauge.svelte
+++ b/src/lib/gauge/Gauge.svelte
@@ -5,8 +5,8 @@
 	export let className: string | undefined = undefined;
 	export let use: UseActions = [];
 	export let percentage: number | 0;
-	export let leftText: string;
-	export let rightText: string;
+	export let leftText: string = '';
+	export let rightText: string = '';
 
 	const max = 100;
 	const min = 0;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,6 +23,7 @@ export { default as Chip } from './chip/Chip.svelte';
 export { default as Collapsible } from './collapsible/Collapsible.svelte';
 export { default as Drawer } from './drawer/Drawer.svelte';
 export { default as Footer } from './footer/Footer.svelte';
+export { default as Gauge } from './gauge/Gauge.svelte';
 export { default as Jumbotron } from './jumbotron/Jumbotron.svelte';
 export { default as Stepper } from './Stepper.svelte';
 export { default as Typography } from './Typography.svelte';

--- a/src/routes/(docs)/components/Gauge/+page.svelte
+++ b/src/routes/(docs)/components/Gauge/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import Typography from '$lib/Typography.svelte';
+	import CodeSnippet from '../CodeSnippet.svelte';
+	import PageHeader from '../PageHeader.svelte';
+	import UsageSection from '../UsageSection.svelte';
+	import * as usage from '../../../usage/gauge/+page.svelte?usage';
+	import * as importUsage from 'virtual:usage/Gauge';
+</script>
+
+<PageHeader title="Gauge" subtitle="Using data as a measure of speed or progress towards a goal." />
+<CodeSnippet code={importUsage} lang="typescript" />
+<div class="mt-12">
+	<Typography variant="heading" as="h3" class="mb-8">Usage</Typography>
+
+	<div class="space-y-8">
+		<UsageSection title="Basic Gauge" src="/usage/gauge" code={usage} />
+	</div>
+</div>

--- a/src/routes/(docs)/components/index.ts
+++ b/src/routes/(docs)/components/index.ts
@@ -12,6 +12,7 @@ export const components = [
 	{ name: 'Drawer' },
 	{ name: 'Dropdown Menu', href: '/components/DropdownMenu' },
 	{ name: 'Footer' },
+	{ name: 'Gauge' },
 	{ name: 'Jumbotron' },
 	{ name: 'Loader' },
 	{ name: 'Nav Bar', href: '/components/NavBar' },

--- a/src/routes/usage/gauge/+page.svelte
+++ b/src/routes/usage/gauge/+page.svelte
@@ -3,5 +3,5 @@
 </script>
 
 <!-- START USAGE -->
-<Gauge percentage={80} leftText="Incomplete" rightText="Complete" />
+<Gauge percentage={80} />
 <!-- END USAGE -->

--- a/src/routes/usage/gauge/+page.svelte
+++ b/src/routes/usage/gauge/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Gauge } from '$lib';
+</script>
+
+<!-- START USAGE -->
+<Gauge percentage={80} leftText="Incomplete" rightText="Complete" />
+<!-- END USAGE -->


### PR DESCRIPTION
Closes #1139

Added a Gauge component to use data as a measure of speed or progress towards a goal with the props of `percentage`, `leftLabel` and `rightLabel`

<img width="635" alt="Screenshot 2023-11-28 at 13 20 33" src="https://github.com/StafflinePeoplePlus/peopleplus-components/assets/79071385/5ae0779a-9175-47ae-bb4a-2e3502480891">
