### PR TITLE
rename package to be under npm org

### DIFF
--- a/.changeset/early-olives-destroy.md
+++ b/.changeset/early-olives-destroy.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": minor
+---
+
+move package into peopleplus npm organisation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# pp-svelte-components
+# @peopleplus/components
 
 ## 0.0.36
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "pp-svelte-components",
+	"name": "@peopleplus/components",
 	"description": "A collection of Svelte components using tailwind.",
 	"license": "MIT",
 	"version": "0.0.36",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,7 +94,7 @@ function codeUsage() {
 				});
 
 				const imports = id.slice(('\0' + usageVirtual).length).split(',');
-				const code = `import { ${imports.join(', ')} } from 'pp-svelte-components';`;
+				const code = `import { ${imports.join(', ')} } from '@peopleplus/components';`;
 				const highlighted = highlighter.codeToHtml(code, { lang: 'typescript' });
 				return `export const html = ${JSON.stringify(highlighted)};
 						export const text = ${JSON.stringify(code)};`;
@@ -108,7 +108,7 @@ function codeUsage() {
 					encoding: 'utf8',
 				});
 				const highlighter = await getHighlighter({ theme: 'github-dark-dimmed' });
-				const code = extractUsage(contents).replaceAll('$lib', 'pp-svelte-components');
+				const code = extractUsage(contents).replaceAll('$lib', '@peopleplus/components');
 				const highlighted = highlighter.codeToHtml(code, { lang: lang });
 
 				return {


### PR DESCRIPTION
I'd like to get a `0.1.0` release out to make it easier to share the components across packages. Right now as we are on 0.0.x releases, every release counts as a breaking release and as such it makes every version incompatible with another from NPM's perspective. This makes using packages that depend on the components (such as `@peopleplus/cohort-management`) annoying to use and maintain as every update to the components requires an update to the dependent package.

This PR contains a changeset that will bump the minor version and I'm also taking this opportunity to rename the package from `pp-svelte-components` to `@peopleplus/components`.