### PR TITLE
import lucide icons directly for faster build times

### DIFF
--- a/.changeset/dull-ducks-bow.md
+++ b/.changeset/dull-ducks-bow.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+import lucide icons directly for faster build times

--- a/src/lib/collapsible/Collapsible.svelte
+++ b/src/lib/collapsible/Collapsible.svelte
@@ -2,7 +2,7 @@
 	import { createCollapsible } from '@melt-ui/svelte';
 	import { slide } from 'svelte/transition';
 	import { actions, type UseActions } from '$lib/actions';
-	import { ChevronDown } from 'lucide-svelte';
+	import ChevronDown from 'lucide-svelte/icons/chevron-down';
 	import { twMerge } from 'tailwind-merge';
 
 	const {
@@ -16,16 +16,16 @@
 	export let use: UseActions = [];
 </script>
 
-<div class={twMerge('bg-white shadow rounded-xl', className)} use:actions={use} {...$$restProps}>
+<div class={twMerge('rounded-xl bg-white shadow', className)} use:actions={use} {...$$restProps}>
 	<div {...$root} use:root>
 		<div
-			class="flex hover:cursor-pointer hover:bg-gray-50 rounded-xl justify-between"
+			class="flex justify-between rounded-xl hover:cursor-pointer hover:bg-gray-50"
 			{...$trigger}
 			use:trigger
 		>
 			<slot name="label" />
 			<div
-				class={twMerge('place-self-end sm:place-self-center max-sm:mb-2 mx-3', iconClass)}
+				class={twMerge('mx-3 place-self-end max-sm:mb-2 sm:place-self-center', iconClass)}
 				class:rotate-180={$open}
 			>
 				<ChevronDown />

--- a/src/lib/toaster/Toast.svelte
+++ b/src/lib/toaster/Toast.svelte
@@ -3,7 +3,10 @@
 	import type { ToastMessage } from './types';
 	import { twMerge } from 'tailwind-merge';
 	import { onMount, createEventDispatcher } from 'svelte';
-	import { XCircleIcon, CheckCircleIcon, XIcon, AlertCircle } from 'lucide-svelte';
+	import XCircleIcon from 'lucide-svelte/icons/x-circle';
+	import CheckCircleIcon from 'lucide-svelte/icons/check-circle';
+	import XIcon from 'lucide-svelte/icons/x';
+	import AlertCircle from 'lucide-svelte/icons/alert-circle';
 
 	const dispatch = createEventDispatcher<{ dismiss: undefined }>();
 	export let toast: ToastMessage;

--- a/src/lib/video/FullscreenButton.svelte
+++ b/src/lib/video/FullscreenButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { MaximizeIcon, MinimizeIcon } from 'lucide-svelte';
+	import MaximizeIcon from 'lucide-svelte/icons/maximize';
+	import MinimizeIcon from 'lucide-svelte/icons/minimize';
 	import { onMount } from 'svelte';
 
 	export let fullscreen = false;

--- a/src/lib/video/VideoPlayer.svelte
+++ b/src/lib/video/VideoPlayer.svelte
@@ -2,7 +2,8 @@
 	import { createEventDispatcher } from 'svelte';
 	import { twJoin, twMerge } from 'tailwind-merge';
 	import debounce from 'just-debounce-it';
-	import { PauseIcon, PlayIcon } from 'lucide-svelte';
+	import PauseIcon from 'lucide-svelte/icons/pause';
+	import PlayIcon from 'lucide-svelte/icons/play';
 
 	const dispatchEvent = createEventDispatcher();
 

--- a/src/lib/video/VolumeControl.svelte
+++ b/src/lib/video/VolumeControl.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { Volume1Icon, Volume2Icon, VolumeXIcon } from 'lucide-svelte';
+	import Volume1Icon from 'lucide-svelte/icons/volume-1';
+	import Volume2Icon from 'lucide-svelte/icons/volume-2';
+	import VolumeXIcon from 'lucide-svelte/icons/volume-x';
 	import VerticalRange from './VerticalRange.svelte';
 
 	export let volume = 1;

--- a/src/routes/(docs)/components/CodeSnippet.svelte
+++ b/src/routes/(docs)/components/CodeSnippet.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { ClipboardCheckIcon, ClipboardIcon } from 'lucide-svelte';
+	import ClipboardCheckIcon from 'lucide-svelte/icons/clipboard-check';
+	import ClipboardIcon from 'lucide-svelte/icons/clipboard';
 	import { twMerge } from 'tailwind-merge';
 
 	let className = '';

--- a/src/routes/usage/dropdownMenu/+page.svelte
+++ b/src/routes/usage/dropdownMenu/+page.svelte
@@ -6,7 +6,10 @@
 		DropdownMenuItem,
 		createDropdownMenu,
 	} from '$lib';
-	import { Trash2Icon, MoreHorizontalIcon, PenIcon, EyeIcon } from 'lucide-svelte';
+	import Trash2Icon from 'lucide-svelte/icons/trash-2';
+	import MoreHorizontalIcon from 'lucide-svelte/icons/more-horizontal';
+	import PenIcon from 'lucide-svelte/icons/pen';
+	import EyeIcon from 'lucide-svelte/icons/eye';
 
 	const { trigger, menu } = createDropdownMenu();
 </script>

--- a/src/routes/usage/navbar/+page.svelte
+++ b/src/routes/usage/navbar/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { NavBar, NavBarNav, NavItem, TextInput, InputArea } from '$lib';
-	import { SearchIcon } from 'lucide-svelte';
+	import SearchIcon from 'lucide-svelte/icons/search';
 </script>
 
 <!-- START USAGE -->

--- a/src/routes/usage/sidebar/+page.svelte
+++ b/src/routes/usage/sidebar/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 	import { Avatar, Sidebar, SidebarItem } from '$lib';
-	import {
-		BellIcon,
-		HomeIcon,
-		ListTodo,
-		LogOutIcon,
-		MessagesSquareIcon,
-		SettingsIcon,
-	} from 'lucide-svelte';
+	import BellIcon from 'lucide-svelte/icons/bell';
+	import HomeIcon from 'lucide-svelte/icons/home';
+	import ListTodo from 'lucide-svelte/icons/list-todo';
+	import LogOutIcon from 'lucide-svelte/icons/log-out';
+	import MessagesSquareIcon from 'lucide-svelte/icons/messages-square';
+	import SettingsIcon from 'lucide-svelte/icons/settings';
 </script>
 
 <div

--- a/src/routes/usage/sortable/grid/+page.svelte
+++ b/src/routes/usage/sortable/grid/+page.svelte
@@ -4,7 +4,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import { flip } from 'svelte/animate';
 	import { writable } from 'svelte/store';
-	import { GripHorizontalIcon } from 'lucide-svelte';
+	import GripHorizontalIcon from 'lucide-svelte/icons/grip-horizontal';
 
 	let items = Array.from({ length: 20 }).map((_, i) => ({
 		id: i.toString(),

--- a/src/routes/usage/sortable/horizontal/+page.svelte
+++ b/src/routes/usage/sortable/horizontal/+page.svelte
@@ -4,7 +4,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import { flip } from 'svelte/animate';
 	import { writable } from 'svelte/store';
-	import { GripVerticalIcon } from 'lucide-svelte';
+	import GripVerticalIcon from 'lucide-svelte/icons/grip-vertical';
 
 	let items = Array.from({ length: 20 }).map((_, i) => ({
 		id: i.toString(),

--- a/src/routes/usage/sortable/vertical/+page.svelte
+++ b/src/routes/usage/sortable/vertical/+page.svelte
@@ -4,7 +4,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import { flip } from 'svelte/animate';
 	import { writable } from 'svelte/store';
-	import { GripVerticalIcon } from 'lucide-svelte';
+	import GripVerticalIcon from 'lucide-svelte/icons/grip-vertical';
 
 	let items = Array.from({ length: 20 }).map((_, i) => ({
 		id: i.toString(),

--- a/src/routes/usage/tooltip/+page.svelte
+++ b/src/routes/usage/tooltip/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, Tooltip } from '$lib';
-	import { BookmarkPlus } from 'lucide-svelte';
+	import BookmarkPlus from 'lucide-svelte/icons/bookmark-plus';
 </script>
 
 <!-- START USAGE -->

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"types": ["vitest-dom/extend-expect"]
-	}
+		"types": ["vitest-dom/extend-expect"],
+	},
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes


### PR DESCRIPTION
saves transpiling _all_ icons on build, saves about 5 seconds locally on a build of this project, saves 2-3x that in other projects.