### PR TITLE
support dark mode tooltips, improve default behaviour

### DIFF
--- a/.changeset/selfish-readers-tickle.md
+++ b/.changeset/selfish-readers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": minor
+---
+
+support dark mode on tooltips, improve default behaviour whilst making it configurable

--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
-	<body class="h-full">
+	<body class="flex h-full flex-col">
 		<div class="contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/floating.ts
+++ b/src/lib/floating.ts
@@ -1,0 +1,5 @@
+type Alignment = 'start' | 'end';
+type Side = 'top' | 'right' | 'bottom' | 'left';
+type AlignedPlacement = `${Side}-${Alignment}`;
+export type FloatingPlacement = Side | AlignedPlacement;
+export type FloatingStrategy = 'absolute' | 'fixed';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ export * from './actions';
 export * from './breadcrumbs';
 export * from './cookies';
 export * from './dropdownMenu';
+export * from './floating';
 export * from './forms';
 export * from './loader';
 export * from './navbar';

--- a/src/lib/popover/action.ts
+++ b/src/lib/popover/action.ts
@@ -1,14 +1,12 @@
 import { createPopover as createMeltPopover } from '@melt-ui/svelte';
+import type { FloatingPlacement, FloatingStrategy } from '../floating';
 
-type Alignment = 'start' | 'end';
-type Side = 'top' | 'right' | 'bottom' | 'left';
-type AlignedPlacement = `${Side}-${Alignment}`;
-export type Placement = Side | AlignedPlacement;
-export type Strategy = 'absolute' | 'fixed';
+// for backwards compatibility
+export type { FloatingPlacement as Placement, FloatingStrategy as Strategy };
 
 export type PopoverOptions = {
-	placement?: Placement;
-	strategy?: Strategy;
+	placement?: FloatingPlacement;
+	strategy?: FloatingStrategy;
 };
 export type PopoverInstance = ReturnType<typeof createPopover>;
 export function createPopover({ placement = 'top', strategy = 'absolute' }: PopoverOptions = {}) {

--- a/src/lib/tooltip/Tooltip.svelte
+++ b/src/lib/tooltip/Tooltip.svelte
@@ -1,23 +1,16 @@
 <script lang="ts">
+	import type { FloatingPlacement } from '$lib/floating';
 	import { createTooltip } from '@melt-ui/svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
-	export let placement:
-		| 'top'
-		| 'top-start'
-		| 'top-end'
-		| 'right'
-		| 'right-start'
-		| 'right-end'
-		| 'bottom'
-		| 'bottom-start'
-		| 'bottom-end'
-		| 'left'
-		| 'left-start'
-		| 'left-end'
-		| undefined = 'top';
+	export let placement: FloatingPlacement | undefined = 'top';
 	export let tooltipClass: string | undefined = undefined;
+	export let openDelay: number = 300;
+	export let closeDelay: number = 0;
+	export let closeOnPointerDown: boolean = true;
+	export let allowHoverableContent: boolean = false;
+
 	let className: string | undefined = undefined;
 	export { className as class };
 
@@ -28,9 +21,10 @@
 		positioning: {
 			placement,
 		},
-		openDelay: 0,
-		closeDelay: 0,
-		closeOnPointerDown: false,
+		openDelay,
+		closeDelay,
+		closeOnPointerDown,
+		disableHoverableContent: !allowHoverableContent,
 		forceVisible: true,
 	});
 </script>
@@ -44,9 +38,12 @@
 		{...$content}
 		use:content
 		transition:fade={{ duration: 100 }}
-		class={twMerge('z-10 rounded-lg shadow p-2 bg-white', tooltipClass)}
+		class={twMerge(
+			'z-50 rounded-lg border border-gray-200 bg-white p-2 text-black shadow dark:border-gray-600 dark:bg-gray-700 dark:text-white',
+			tooltipClass,
+		)}
 	>
-		<div {...$arrow} use:arrow class="border-t border-l" />
+		<div {...$arrow} use:arrow class="border-l border-t border-gray-200 dark:border-gray-600" />
 		<slot name="tooltip" />
 	</div>
 {/if}

--- a/src/routes/usage/+layout.svelte
+++ b/src/routes/usage/+layout.svelte
@@ -1,3 +1,3 @@
-<div class="h-full p-8 dark:bg-gray-900">
+<div class="grow p-8 dark:bg-gray-900">
 	<slot />
 </div>

--- a/src/routes/usage/tooltip/+page.svelte
+++ b/src/routes/usage/tooltip/+page.svelte
@@ -3,12 +3,14 @@
 	import BookmarkPlus from 'lucide-svelte/icons/bookmark-plus';
 </script>
 
-<!-- START USAGE -->
-<Tooltip class="my-5">
-	<Button href="/">
-		<BookmarkPlus />
-	</Button>
+<div class="mt-8 flex justify-center">
+	<!-- START USAGE -->
+	<Tooltip>
+		<div slot="tooltip">Save Bookmark</div>
 
-	<div slot="tooltip">Save Bookmark</div>
-</Tooltip>
-<!-- END USAGE -->
+		<Button>
+			<BookmarkPlus />
+		</Button>
+	</Tooltip>
+	<!-- END USAGE -->
+</div>

--- a/src/routes/usage/tooltip/custom/+page.svelte
+++ b/src/routes/usage/tooltip/custom/+page.svelte
@@ -3,11 +3,9 @@
 </script>
 
 <!-- START USAGE -->
-<Tooltip placement="right" class="mb-10" tooltipClass="text-xs rounded">
-	<InputLabel for="example">Password</InputLabel>
-	<div>
-		<input name="example" id="example" type="password" class="rounded border p-2 mt-1" />
-	</div>
+<InputLabel for="example">Password</InputLabel>
+<Tooltip placement="right" tooltipClass="text-xs rounded" closeOnPointerDown={false}>
+	<input name="example" id="example" type="password" class="mt-1 rounded border p-2" />
 
 	<div slot="tooltip">
 		Password should contain at least:


### PR DESCRIPTION
- adds dark mode support to tooltips
- fixes light mode when a text color wasn't already set
- fixed up the usage template to render things a little nicer
- improved the behaviour of the tooltip by:
  - including a small delay by default
  - closing the tooltip on pointer down by default
  - disabling hoverable content by default
- all of the above is configurable now
- share floating types between tooltip and popover