### PR TITLE
allow passing 'open' store to popover

### DIFF
--- a/.changeset/popular-dragons-beg.md
+++ b/.changeset/popular-dragons-beg.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+allow passing 'open' store to popover

--- a/src/lib/popover/action.ts
+++ b/src/lib/popover/action.ts
@@ -1,5 +1,6 @@
 import { createPopover as createMeltPopover } from '@melt-ui/svelte';
 import type { FloatingPlacement, FloatingStrategy } from '../floating';
+import type { Writable } from 'svelte/store';
 
 // for backwards compatibility
 export type { FloatingPlacement as Placement, FloatingStrategy as Strategy };
@@ -10,6 +11,7 @@ export type PopoverOptions = {
 	flip?: boolean;
 	overlap?: boolean;
 	sameWidth?: boolean;
+	open?: Writable<boolean>;
 };
 export type PopoverInstance = ReturnType<typeof createPopover>;
 export function createPopover({
@@ -18,25 +20,27 @@ export function createPopover({
 	flip = true,
 	overlap = false,
 	sameWidth = false,
+	open,
 }: PopoverOptions = {}) {
 	const {
 		elements: { trigger, content, arrow },
-		states: { open },
+		states: { open: openState },
 	} = createMeltPopover({
 		positioning: { placement, strategy, flip, overlap, sameWidth },
 		forceVisible: true,
+		open,
 	});
 
 	return {
 		button: trigger,
 		content,
 		arrow,
-		expanded: open,
+		expanded: openState,
 		open() {
-			open.set(true);
+			openState.set(true);
 		},
 		close() {
-			open.set(false);
+			openState.set(false);
 		},
 	};
 }


### PR DESCRIPTION
allows controlling the popover from an externally provided source, for example to prevent more then one popover in some defined group from being open at any one time.