### PR TITLE
fix DropdownMenu `menu` type in generated types

### DIFF
--- a/.changeset/nasty-frogs-melt.md
+++ b/.changeset/nasty-frogs-melt.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+fix generated type name overwriting imported type name cause the DropdownMenu `menu` prop to be typed incorrectly

--- a/src/lib/dropdownMenu/DropdownMenu.svelte
+++ b/src/lib/dropdownMenu/DropdownMenu.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { setContext } from 'svelte';
-	import { dropdownMenuContext, type DropdownMenu } from './menu.js';
+	import { dropdownMenuContext, type DropdownMenu as DropdownMenuType } from './menu.js';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
 	let className: string | undefined = undefined;
 	export { className as class };
-	export let menu: DropdownMenu;
+	export let menu: DropdownMenuType;
 
 	setContext(dropdownMenuContext, menu);
 


### PR DESCRIPTION
When the component is generated, a class with the same name as the file is created. This happened to match the name of the imported type `DropdownMenu` causing the class to be used instead of the imported type for the `menu` property. This caused type mismatches when trying to use this property.