### PR TITLE
allow disabling click outside to close on popovers

### DIFF
--- a/.changeset/cuddly-goats-brake.md
+++ b/.changeset/cuddly-goats-brake.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+expose close action/props from melt-ui popover

--- a/.changeset/old-schools-yawn.md
+++ b/.changeset/old-schools-yawn.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+allow disabling click outside on popovers

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test-results
 .nyc_output
 package-lock.json
 /playwright-report
+*.svelte.d.ts
 # Devenv
 .devenv*
 devenv.local.nix

--- a/src/lib/popover/action.ts
+++ b/src/lib/popover/action.ts
@@ -12,6 +12,7 @@ export type PopoverOptions = {
 	overlap?: boolean;
 	sameWidth?: boolean;
 	open?: Writable<boolean>;
+	disableClickOutside?: boolean;
 };
 export type PopoverInstance = ReturnType<typeof createPopover>;
 export function createPopover({
@@ -20,19 +21,22 @@ export function createPopover({
 	flip = true,
 	overlap = false,
 	sameWidth = false,
+	disableClickOutside = false,
 	open,
 }: PopoverOptions = {}) {
 	const {
-		elements: { trigger, content, arrow },
+		elements: { trigger, content, arrow, close },
 		states: { open: openState },
 	} = createMeltPopover({
 		positioning: { placement, strategy, flip, overlap, sameWidth },
 		forceVisible: true,
 		open,
+		closeOnOutsideClick: !disableClickOutside,
 	});
 
 	return {
 		button: trigger,
+		closeButton: close,
 		content,
 		arrow,
 		expanded: openState,


### PR DESCRIPTION
also exposes the close action/props from the melt-ui popover