### PR TITLE
Update workflows to use nodejs v20

### DIFF
--- a/.changeset/silly-fishes-speak.md
+++ b/.changeset/silly-fishes-speak.md
@@ -1,0 +1,5 @@
+---
+"@peopleplus/components": patch
+---
+
+Update github actions nodejs version

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js 18 🛒
+      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Node Packages 🛒
         run: npm i

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 
 jobs:
   test:

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -98,7 +98,7 @@ jobs:
         run: sleep 10
 
       - name: Accessibility scan 🩻
-        uses: a11ywatch/github-actions@v1.14.1
+        uses: a11ywatch/github-actions@v2.1.10
         with:
           WEBSITE_URL: '$(hostname):4173'
           SUBDOMAINS: false

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
+      - name: Use Node.js 18 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 18.x
 
       - name: Install Node Packages 🛒
         run: npm i

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  NODE_VERSION: 20.x
+
 jobs:
   publish:
     name: Release
@@ -16,10 +19,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js 18 🛒
+      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Node Packages 🛒
         run: npm i
@@ -52,10 +55,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js 18 🛒
+      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Node Packages 🛒
         run: npm i

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -6,7 +6,7 @@ on:
       - uat
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 20.x
 
 jobs:
   test:

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -79,10 +79,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js 18 🛒
+      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Node Packages 🛒
         run: npm i
@@ -97,7 +97,7 @@ jobs:
         run: sleep 10
 
       - name: Accessibility scan 🩻
-        uses: a11ywatch/github-actions@v1.14.1
+        uses: a11ywatch/github-actions@v2.1.10
         with:
           WEBSITE_URL: ${{ vars.UAT_URL }}
           SUBDOMAINS: false

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -79,10 +79,10 @@ jobs:
       - name: Checkout 🛒
         uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ env.NODE_VERSION }} 🛒
+      - name: Use Node.js 18 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 18.x
 
       - name: Install Node Packages 🛒
         run: npm i

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+env:
+  NODE_VERSION: 20.x
 
 jobs:
   release:
@@ -13,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js ${{ env.NODE_VERSION }} 🛒
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Dependencies
         run: npm i


### PR DESCRIPTION
Fixes issues with recently updated dependencies now requiring nodejs v20+ (long term support for node 18 ends in the next 2/3 months)